### PR TITLE
Adjusted possible responses for getData for method to avoid errors.

### DIFF
--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -109,12 +109,13 @@ class Database implements \IteratorAggregate, \Countable {
      */
     protected function getRowKey(int $id): int
     {
-        foreach ($this->getData() as $key => $data)
-        {
-            if ($data->id == $id)
-            {
-                return $key;
-                break;
+        $currentData = $this->getData();
+        if (is_array($currentData)) {
+            foreach ($currentData as $key => $data) {
+                if ($data->id == $id) {
+                    return $key;
+                    break;
+                }
             }
         }
         throw new LazerException('No data found with ID: ' . $id);

--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -86,9 +86,9 @@ class Database implements \IteratorAggregate, \Countable {
     /**
      * Get rows from table
      * @uses \Lazer\Classes\Helpers\Data::get() to get data from file
-     * @return array
+     * @return array|null
      */
-    protected function getData(): array
+    protected function getData()
     {
         return Helpers\Data::table($this->name)->get();
     }

--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -86,11 +86,11 @@ class Database implements \IteratorAggregate, \Countable {
     /**
      * Get rows from table
      * @uses \Lazer\Classes\Helpers\Data::get() to get data from file
-     * @return array|null
+     * @return array
      */
-    protected function getData()
+    protected function getData(): array
     {
-        return Helpers\Data::table($this->name)->get();
+        return Helpers\Data::table($this->name)->get() ?? [];
     }
 
     /**
@@ -109,13 +109,12 @@ class Database implements \IteratorAggregate, \Countable {
      */
     protected function getRowKey(int $id): int
     {
-        $currentData = $this->getData();
-        if (is_array($currentData)) {
-            foreach ($currentData as $key => $data) {
-                if ($data->id == $id) {
-                    return $key;
-                    break;
-                }
+        foreach ($this->getData() as $key => $data)
+        {
+            if ($data->id == $id)
+            {
+                return $key;
+                break;
             }
         }
         throw new LazerException('No data found with ID: ' . $id);

--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -90,7 +90,7 @@ class Database implements \IteratorAggregate, \Countable {
      */
     protected function getData(): array
     {
-        return Helpers\Data::table($this->name)->get() ?? [];
+        return Helpers\Data::table($this->name)->get(true) ?? [];
     }
 
     /**

--- a/src/Classes/Helpers/Config.php
+++ b/src/Classes/Helpers/Config.php
@@ -89,7 +89,7 @@ class Config extends File {
      */
     public function schema(): array
     {
-        return $this->getKey('schema', true);
+        return $this->getKey('schema', true) ?? [];
     }
 
     /**

--- a/src/Classes/Helpers/Config.php
+++ b/src/Classes/Helpers/Config.php
@@ -26,7 +26,13 @@ class Config extends File {
      */
     public function getKey(string $field, bool $assoc = false)
     {
-        return $assoc ? $this->get($assoc)[$field] : $this->get($assoc)->{$field};
+        $value = $this->get($assoc);
+
+        if (null === $value) {
+            return null;
+        }
+
+        return $assoc ? $value[$field] : $value->{$field};
     }
 
     /**
@@ -50,7 +56,8 @@ class Config extends File {
      */
     public function fields(): array
     {
-        return array_keys($this->getKey('schema', true));
+        $keys = $this->getKey('schema', true);
+        return $keys ? array_keys($keys) : [];
     }
 
     /**


### PR DESCRIPTION
Hello,

Thank you for this library, awesome work here.

Deeper in that method, we find a `json_decode` at the `vendor/greg0/lazer-database/src/Classes/Helpers/File.php:85`. One of possible returns for that function is null, which happens more than ideal. To avoid errors to be logged without necessity I added this small change. From PHP 8 forward we will be able to use union types (`array|null`).

Please, let me know if you have any concerns or if this is not ideal.

Cheers,
Savio